### PR TITLE
changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,11 +45,12 @@ def loadinvites():
         pass
     print("Loaded invites")
 
-# Update bot.Invites
+# Update Invites
 def update_invites_file():
     with open("invites.txt", "w") as f:
         for author_id, invite_data in bot.invites.items():
-            f.write(f"{author_id};{invite_data['url']};{invite_data['uses']};{';'.join(map(str, invite_data['users']))}1\n")
+            for invite in invite_data:
+                f.write(f"{author_id};{invite['url']};{invite['uses']};{';'.join(map(str, invite_data['users']))}1\n")
 
 # On Join
 @bot.event

--- a/main.py
+++ b/main.py
@@ -1,55 +1,52 @@
 # Imports
 import discord
 from discord.ext import commands
-
+from collections import defaultdict
 # Create Bot
-bot = discord.Bot(intents=discord.Intents.all())
+intents = discord.Intents.none()
+intents.members = True
+intents.bot.invites = True 
+bot = discord.Bot(intents=intents)
 
 # Setup List
-invites = {}
+bot.invites = defaultdict(list, {})
 referralamounts = {}
 
-# Create Invites
-@bot.command(description="Creates an invite for you.")
-async def createinvite(ctx):
-    author_id = str(ctx.author.id)
-    if author_id in invites:
-        await ctx.respond(f"You already have an invite: {invites[author_id]['url']} with {invites[author_id]['uses']} uses.")
-        return
-    invite = await ctx.channel.create_invite(max_uses=0)
-    invites[author_id] = {"url": invite.url, "uses": 0, "users": []}
+@bot.event
+async def on_invite_create(invite):
+    bot.invites[invite.inviter.id]+=[{url : invite.url, "uses": 0, "users": []}]
     update_invites_file()
-    await ctx.respond(f"Here is your invite: {invite.url}")
-    print("New Invite Created")
-
 # Returns Your Existing Invite
 @bot.command(description="Responds with your invite.")
-async def myinvite(ctx):
+async def myinvites(ctx):
     author_id = str(ctx.author.id)
-    if author_id in invites:
-        await ctx.respond(f"Your invite: {invites[author_id]['url']} has {invites[author_id]['uses']} uses.")
-    else:
-        await ctx.respond("You don't have an invite.")
+    my_invites = [i for i in bot.invites if author_id == i['author_id']]
+    if not my_invites:
+        return await ctx.respond("You don't have an invite.")
+    embed = discord.Embed(title="Your invites", color="#934")
+    for c,i in enumerate(my_invites):
+        embed.add_field(name=f'{c}. {i["url"]}', value=f"**Uses**: {i['uses']}", inline=True)
+    await ctx.respond(embed=embed)
+        
 
-# Load Invites
+# Load bot.Invites
 def loadinvites():
-    global invites
-    invites = {}
-
+    tmp_invites = defaultdict(list, {})
     try:
         with open("invites.txt") as f:
             for line in f:
                 data = line.strip().split(";")
                 author_id, invite_url, uses, *users = data
-                invites[author_id] = {"url": invite_url, "uses": int(uses), "users": [int(user) for user in users]}
+                tmp_invites[author_id] += [{"url": invite_url, "uses": int(uses), "users": [int(user) for user in users]}]
+        bot.invites = tmp_invites
     except FileNotFoundError:
         pass
-    print("Loaded Invites")
+    print("Loaded invites")
 
-# Update Invites
+# Update bot.Invites
 def update_invites_file():
     with open("invites.txt", "w") as f:
-        for author_id, invite_data in invites.items():
+        for author_id, invite_data in bot.invites.items():
             f.write(f"{author_id};{invite_data['url']};{invite_data['uses']};{';'.join(map(str, invite_data['users']))}1\n")
 
 # On Join
@@ -66,17 +63,17 @@ async def on_member_join(member):
             max_timestamp = inv.created_at.timestamp()
             most_recent = inv
     if most_recent:
-        for author_id, invite_data in invites.items():
+        for author_id, invite_data in bot.invites.items():
             if invite_data['url'] == most_recent.url:
-                invites[author_id]["uses"] += 1
-                invites[author_id]["users"].append(member.id)
+                bot.invites[author_id]["uses"] += 1
+                bot.invites[author_id]["users"].append(member.id)
                 invited_by = guild.get_member(author_id)
                 invites_amount = invite_data["uses"]
                 break
     else:
         invited_by = None
         invites_amount = None
-    update_invites_file()
+    update_bot.invites_file()
     channel = bot.get_channel(1070649769707458590) # This Channel ID Can Be Changed To Any
     await channel.send(f"{member.mention} joined the server.")
 
@@ -84,15 +81,18 @@ async def on_member_join(member):
 @bot.command(description="Responds with the inviter of the mentioned user.")
 async def inviter(ctx, member: discord.Member):
     author_id = None
-    for invite_author_id, invite_data in invites.items():
-        if member.id in invite_data["users"]:
-            author_id = invite_author_id
+    for invite_author_id, invite_datas in bot.invites.items():
+        k = False
+        for invite in invite_datas:
+            if member.id in invite["users"]:
+                author_id = invite_author_id
+                break
+        if k:
             break
-    if author_id is None:
-        await ctx.respond("Could not find the inviter.")
-    else:
-        inviter = ctx.guild.get_member(int(author_id))
-        await ctx.respond(f"{member.mention} was invited by {inviter.mention}")
+    if not author_id:
+        return await ctx.respond("Could not find the inviter.")
+    inviter = ctx.guild.get_member(int(author_id))
+    await ctx.respond(f"{member.mention} was invited by {inviter.mention}")
 
 
 
@@ -115,8 +115,7 @@ async def referraladd(ctx, member: discord.Member, amount: int):
 # Check Referral Amount
 @bot.command(description="Responds with the referral amount of the mentioned user or the author if no user is specified.")
 async def referralamount(ctx, member: discord.Member = None):
-    if member is None:
-        member = ctx.author
+    member = member or ctx.author
     member_id = str(member.id)
     if member_id not in referralamounts:
         referralamounts[member_id] = 0
@@ -130,7 +129,7 @@ async def quickreferraladd(ctx, member: discord.Member, amount: int):
         return
     member_id = str(member.id)
     inviter = None
-    for invite_author_id, invite_data in invites.items():
+    for invite_author_id, invite_data in bot.invites.items():
         if member.id in invite_data["users"]:
             inviter = ctx.guild.get_member(int(invite_author_id))
             break

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ load_dotenv()
 # Create Bot
 intents = discord.Intents.none()
 intents.members = True
-intents.bot.invites = True 
+intents.invites = True 
 bot = discord.Bot(intents=intents)
 
 # Setup List

--- a/main.py
+++ b/main.py
@@ -56,6 +56,7 @@ def update_invites_file():
 async def on_member_join(member):
     print("member joined")
     guild_invites = await guild.invites()
+    vanity = True
     for author_id, invite_datas in bot.invites.items():
         for c, invite in enumerate(invite_datas):
             g_invite = next((x for x in guild_invites if x.url == invite['url']), None)
@@ -63,10 +64,11 @@ async def on_member_join(member):
                 bot.invites[author_id][c]["uses"] += 1
                 bot.invites[author_id][c]["users"].append(member.id)
                 update_invites_file()
+                vanity = False
                 break
     
     channel = bot.get_channel(os.getenv("WELCOME_CHANNEL")) 
-    await channel.send(f"{member.mention} joined the server.")
+    await channel.send(f"{member.mention} joined the server{' (possibly by vanity)' if vanity else ''}.")
 
 # Gets The Inviter Of A User If They Joined From A Bot Invite
 @bot.command(description="Responds with the inviter of the mentioned user.")


### PR DESCRIPTION
- Used `collections.defaultdict` for `invites` instead of `dict`
- Renamed `invites` to `bot.invites` for performance reasons
- Used `python-dotenv` to load credentials
- Removed `createinvite` and used `on_invite_create` instead
- Used only `members` and `invites` intents
- Allowed for multiple invites by one person
- Fixed the vanity bug